### PR TITLE
Fix failing tests on Windows, path handling updated.

### DIFF
--- a/datapackage/package_test.go
+++ b/datapackage/package_test.go
@@ -490,17 +490,19 @@ func TestLoad(t *testing.T) {
 		f, err := w.Create("datapackage.json")
 		is.NoErr(err)
 
+		osPath := filepath.Join("data", "foo.csv")
+		jPath, _ := json.Marshal(osPath)
 		content := fmt.Sprintf(`{
 			"profile": "data-package",
 			"resources": [
 			  {
 				"encoding": "utf-8",
 				"name": "res1",
-				"path": "data%sfoo.csv",
+				"path": %s,
 				"profile": "data-resource"
 			  }
 			]
-		  }`, string(os.PathSeparator))
+		  }`, string(jPath))
 		_, err = f.Write([]byte(content))
 		is.NoErr(err)
 		// Writing a file which is in a subdir.
@@ -515,7 +517,7 @@ func TestLoad(t *testing.T) {
 		is.NoErr(err)
 		res := pkg.GetResource("res1")
 		is.Equal(res.name, "res1")
-		is.Equal(res.path, []string{"data/foo.csv"})
+		is.Equal(res.path, []string{osPath})
 		contents, err := res.ReadAll()
 		is.NoErr(err)
 		is.Equal(contents[0], []string{"foo"})

--- a/datapackage/resource.go
+++ b/datapackage/resource.go
@@ -274,13 +274,14 @@ func loadContents(basePath string, path []string, f func(string) func() (io.Read
 	return newMultiReadCloser(rcs), nil
 }
 
-func joinPaths(basePath, path string) string {
-	u, err := url.Parse(basePath)
-	if err != nil {
-		return filepath.Join(basePath, path)
+func joinPaths(basePath, part string) string {
+	if isRemotePath(basePath) {
+		u, _ := url.Parse(basePath)
+		u.Path = path.Join(u.Path, part)
+		return u.String()
 	}
-	u.Path = filepath.Join(u.EscapedPath(), path)
-	return u.String()
+
+	return filepath.Join(basePath, part)
 }
 
 // ReadAll reads all rows from the table and return it as strings.


### PR DESCRIPTION
# Overview

This fixes the windows build and introduce no failures on Linux (tested via Docker on Windows).

The crux is the different osSeparators used and how urls/remote paths and local paths convienently can be treated using url's on Linux but this strategy fails on windows. 

The steps thus taken is to distingush between remote and local paths and then use url & path.Join for remote ones and rely on filepath for local ones. 

There's also an issue where osSeparator on windows (\) means that the text used as input for one of the tests ends up being escaped, I fixed that by simply json marshalling the result and splicing it into the string which makes the intent explicit.

---

Please preserve this line to notify @danielfireman (lead of this repository)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/frictionlessdata/datapackage-go/31)
<!-- Reviewable:end -->
